### PR TITLE
avoid notification about read only dir

### DIFF
--- a/StencylWorks.prefs
+++ b/StencylWorks.prefs
@@ -1,0 +1,4 @@
+global.engine.extension.style=true
+global.extension.style=true
+global.workdir.style=true
+

--- a/com.stencyl.Game.json
+++ b/com.stencyl.Game.json
@@ -40,6 +40,10 @@
                 },
                 {
                     "type": "file",
+                    "path": "StencylWorks.prefs"
+                },
+                {
+                    "type": "file",
                     "path": "apply_extra"
                 },
                 {

--- a/resources-Makefile
+++ b/resources-Makefile
@@ -8,3 +8,4 @@ install:
 	install -D com.stencyl.Game.png /app/share/icons/hicolor/128x128/apps/com.stencyl.Game.png
 	install -D com.stencyl.Game.appdata.xml /app/share/appdata/com.stencyl.Game.appdata.xml
 	install -D apply_extra /app/bin/apply_extra
+	install -D StencylWorks.prefs /app/StencylPrefs/StencylWorks.prefs

--- a/stencyl.sh
+++ b/stencyl.sh
@@ -1,3 +1,20 @@
-#!/bin/sh
+#!/bin/bash
+
+set -eu
+
+#
+# Set working directory on first startup.
+#
+# Stencyl by default sets up workspace in /app/extra/Stencyl/,
+# that is read only, so we get a warning notification.
+# This overrides the preferences on start, and sets working directory to $HOME.
+
+PREFS_DIR="$HOME/.StencylWorks"
+
+if [[ ! -f "${PREFS_DIR}/StencylWorks.prefs" ]]; then
+	mkdir -p "${PREFS_DIR}"
+	cp /app/StencylPrefs/StencylWorks.prefs "${PREFS_DIR}/StencylWorks.prefs"
+	echo "global.workdir=${HOME}" >>"${PREFS_DIR}/StencylWorks.prefs"
+fi
 
 exec /app/extra/Stencyl


### PR DESCRIPTION
Stencyl by default sets the working directory as the /app/extra/Stencyl
this is read only, so we get a warning on first start.
This sets up a preferences file with the $HOME as the work directory.

https://phabricator.endlessm.com/T15415

@erikos 