### PR TITLE
install resources files in apply_extra

### DIFF
--- a/apply_extra
+++ b/apply_extra
@@ -4,4 +4,9 @@ tar -xzvf Stencyl-64-full.tar.gz
 rm -rf Stencyl-64-full.tar.gz
 
 # Export stencyl icon
- install -D /app/extra/data/other/icon-30x30.png /app/extra/export/share/icons/hicolor/64x64/apps/com.stencyl.Game.png
+
+install -D /app/extra/data/other/icon-30x30.png /app/extra/export/share/icons/hicolor/64x64/apps/com.stencyl.Game.png
+install -D /app/temp/com.stencyl.Game.desktop /app/extra/export/share/applications/com.stencyl.Game.desktop
+install -D /app/temp/com.stencyl.Game.appdata.xml /app/extra/export/share/appdata/com.stencyl.Game.appdata.xml
+
+rm -rf /app/temp/

--- a/resources-Makefile
+++ b/resources-Makefile
@@ -4,7 +4,7 @@ all:
 install:
 	install -D firefox /app/bin/firefox
 	install -D stencyl.sh /app/bin/stencyl
-	install -D com.stencyl.Game.desktop /app/share/applications/com.stencyl.Game.desktop
-	install -D com.stencyl.Game.appdata.xml /app/share/appdata/com.stencyl.Game.appdata.xml
 	install -D apply_extra /app/bin/apply_extra
 	install -D StencylWorks.prefs /app/StencylPrefs/StencylWorks.prefs
+	install -D com.stencyl.Game.desktop /app/temp/com.stencyl.Game.desktop
+	install -D com.stencyl.Game.appdata.xml /app/temp/com.stencyl.Game.appdata.xml


### PR DESCRIPTION
Due to desktop file missing the icon, which only gets exported during install,
we need to place the other resources then as well.

https://phabricator.endlessm.com/T15415